### PR TITLE
Feat/add tooltips resource links

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Edit, ExternalLink, FolderPlus, Globe, Loader2, Lock, MoreHorizontal, Search, Trash2 } from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
 import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useCollections, type Collection } from '../contexts/CollectionsContext';
@@ -305,7 +306,7 @@ export function Dashboard() {
                       )}
 
                       <div className="flex items-center justify-between">
-                        <a href={resource.link} target="_blank" rel="noopener noreferrer" title={resource.link} className="text-blue-600 hover:text-blue-700 text-sm font-medium inline-flex items-center gap-2"><ExternalLink className="w-4 h-4"/> Visit Link</a>
+                        <a href={resource.link} target="_blank" rel="noopener noreferrer" data-tooltip-id="dashboard-tooltip" data-tooltip-content={resource.link} className="text-blue-600 hover:text-blue-700 text-sm font-medium inline-flex items-center gap-2"><ExternalLink className="w-4 h-4"/> Visit Link</a>
                         <div className="flex items-center gap-2">
                           {assignedCollections.map((collection) => (
                             <span key={collection.id} className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-white" style={{ backgroundColor: collection.color || '#2563eb' }}>{collection.icon || '🗂️'} {collection.name}</span>
@@ -323,6 +324,7 @@ export function Dashboard() {
           </main>
         </div>
       </div>
+      <Tooltip id="dashboard-tooltip" />
     </>
   );
 }

--- a/src/components/SharedDump.tsx
+++ b/src/components/SharedDump.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { CheckCircle, ExternalLink, Filter, Loader2, Plus, Search } from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -227,7 +228,8 @@ export function SharedDump() {
                     href={resource.link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    title={resource.link}
+                    data-tooltip-id="shared-dump-tooltip"
+                    data-tooltip-content={resource.link}
                     className="inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium text-sm"
                   >
                     <ExternalLink className="w-4 h-4" />
@@ -267,6 +269,7 @@ export function SharedDump() {
           })}
         </div>
       )}
+      <Tooltip id="shared-dump-tooltip" />
     </div>
   );
 }

--- a/src/components/ui/MetadataPreviewCard.tsx
+++ b/src/components/ui/MetadataPreviewCard.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from 'lucide-react';
+import { Tooltip } from 'react-tooltip';
 import { EnrichmentResult } from '../../hooks/useUrlEnrichment';
 
 interface MetadataPreviewCardProps {
@@ -33,7 +34,8 @@ export function MetadataPreviewCard({ metadata, url }: MetadataPreviewCardProps)
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:text-blue-700 transition-colors flex-shrink-0"
-              title={url}
+              data-tooltip-id="metadata-tooltip"
+              data-tooltip-content={url}
             >
               <ExternalLink className="w-4 h-4" />
             </a>
@@ -46,6 +48,7 @@ export function MetadataPreviewCard({ metadata, url }: MetadataPreviewCardProps)
           )}
         </div>
       </div>
+      <Tooltip id="metadata-tooltip" />
     </div>
   );
 }


### PR DESCRIPTION
# feat: Add Tooltips to Resource Links

## Description

This PR enhances the user experience by adding tooltips to resource links throughout the application. Users can now hover over "Visit Link" buttons to see the full URL without needing to click and navigate away.

## Changes Made

- **Installed react-tooltip library** for better tooltip functionality
- **Updated SharedDump.tsx**: Added tooltip to resource links showing full URL
- **Updated Dashboard.tsx**: Added tooltip to resource links in the dashboard view
- **Updated MetadataPreviewCard.tsx**: Enhanced existing link tooltip with react-tooltip

## Benefits

- **Quick Preview**: Users can see the destination URL before clicking
- **Better UX**: Reduces navigation friction and improves trust
- **Responsive**: Tooltips work across all devices and browsers
- **Accessible**: Proper ARIA attributes for screen readers

## Before & After

### Before
<img width="1363" height="629" alt="image" src="https://github.com/user-attachments/assets/dbc3d228-6950-483c-a943-82e11b74c7cd" />


### After
<img width="1365" height="627" alt="image" src="https://github.com/user-attachments/assets/698d76d2-4eac-46d3-ba3e-801d98902c9a" />

## Testing

- ✅ Tooltips appear on hover
- ✅ Responsive design maintained
- ✅ No layout breaks
- ✅ Works across browsers

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hover tooltips to resource links throughout the application, displaying link URLs and content on mouseover for improved link visibility and user experience across dashboard and resource sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->