### PR TITLE
fix: ensure react-tooltip package is properly included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^14.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-tooltip": "^5.30.0",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -740,6 +741,31 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
       "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@google-cloud/firestore": {
       "version": "7.11.6",
@@ -2342,6 +2368,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -5165,6 +5197,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.0.tgz",
+      "integrity": "sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "^14.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-tooltip": "^5.30.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Fix: Ensure react-tooltip package is properly included

This PR resolves the missing `react-tooltip` package issue that occurred after merging PR #73.

### Problem
After merging the tooltip implementation PR, the application failed due to missing `react-tooltip` dependency, causing import errors in production.

### Solution
- Added `react-tooltip: ^5.30.0` to `package.json`
- Updated `package-lock.json` to include the dependency
- Verified build passes successfully

### Changes
- `package.json`: Added react-tooltip dependency
- `package-lock.json`: Updated lockfile with new dependency

### Testing
- Build command passes without errors
- Tooltip components import correctly
- No runtime errors related to missing package

This ensures the tooltip functionality works correctly in all environments.

Closes #54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tooltip library dependency to support enhanced user interface interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->