### PR TITLE
chore(docs): add .env.example and document env setup #63

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,58 @@
+# Copy this file to `.env` or `.env.local` and fill in real values. Do NOT commit secrets.
+# This example lists both client and server env vars used by the project.
+
+#############################
+# Client (browser) settings  #
+#############################
+# Next.js (App Router) uses `NEXT_PUBLIC_*` for public client env vars.
+# Some code/comments reference `VITE_*` — include both if you use a Vite-based workflow.
+
+# Next.js public Firebase config (used in `src/lib/firebase.ts`)
+NEXT_PUBLIC_FIREBASE_API_KEY=your_firebase_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
+
+# Optional: alternate client variable names sometimes referenced in docs
+VITE_FIREBASE_API_KEY=your_firebase_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+
+#############################
+# Server (admin) settings    #
+#############################
+# Required for Firebase Admin SDK (used in `app/api/_utils/firebaseAdmin.ts`)
+# These are server-only and must NOT be exposed to the browser.
+
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project.iam.gserviceaccount.com
+# The private key must include newline characters. Use the literal \n sequence as shown
+# OR wrap the value in quotes and include actual newlines depending on your host.
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_CONTENT\n-----END PRIVATE KEY-----\n"
+
+#############################
+# AI / Gemini configuration  #
+#############################
+# Some files reference `VITE_GEMINI_*`; some docs use `GEMINI_*`. Include both.
+
+VITE_GEMINI_API_KEY=your_gemini_api_key
+VITE_GEMINI_MODEL=gemini-2.5-pro
+
+GEMINI_API_KEY=your_gemini_api_key
+GEMINI_MODEL=gemini-2.5-pro
+
+#############################
+# Notes
+#############################
+# - Copy this file to a local env file and populate values:
+#   PowerShell:  Copy-Item .env.example .env
+# - Keep secrets out of version control. `.gitignore` already includes `.env`.
+# - For `FIREBASE_PRIVATE_KEY` ensure newline escaping: replace actual newlines with "\\n"
+#   if your hosting platform requires a single-line env variable.

--- a/FEATURE_AI_ENRICHMENT.md
+++ b/FEATURE_AI_ENRICHMENT.md
@@ -138,6 +138,25 @@ VITE_GEMINI_MODEL=gemini-1.0
 - Temperature set to 0.2 for consistent results
 - Max tokens: 200 for summaries
 
+### How to obtain and configure a Gemini API key
+
+1. Visit the Google Cloud or Google AI console where Gemini/API keys are managed and create an API key for the Gemini model you intend to use.
+2. Add the key to your local `.env` (or `.env.local`) file. This project references `VITE_GEMINI_API_KEY` in code comments; some docs use `GEMINI_API_KEY`. The `.env.example` includes both variants. Example:
+
+```env
+# Client (if enabled):
+VITE_GEMINI_API_KEY=your_gemini_api_key
+VITE_GEMINI_MODEL=gemini-2.5-pro
+
+# Server (preferred for secure calls):
+GEMINI_API_KEY=your_gemini_api_key
+GEMINI_MODEL=gemini-2.5-pro
+```
+
+Notes:
+- Client-side Gemini calls are disabled by default in the codebase to avoid exposing keys in the browser. If you need to enable AI calls from the client, be aware of the security risk—prefer server-side proxying for production.
+- If you enable server-side usage, place `GEMINI_API_KEY` in server environment variables and make requests from server API routes.
+
 ## 🧪 Testing Checklist
 
 ### ✅ Basic Functionality

--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -85,6 +85,28 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=123456789
 VITE_FIREBASE_APP_ID=1:123456789:web:abcdef123456
 ```
 
+### 6.a Firebase Admin (Server) credentials
+
+The server-side code (Firebase Admin SDK) requires service account credentials. Create a service account in the Firebase Console and download the JSON key:
+
+1. Go to **Firebase Console → Project Settings → Service accounts**
+2. Click **Generate new private key** and download the JSON file
+
+From the downloaded JSON, set these environment variables on your server or in your local `.env` (do NOT commit):
+
+```env
+# Server-only (Firebase Admin SDK)
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project.iam.gserviceaccount.com
+# Copy the private_key value from the JSON. If your platform requires a single-line env value
+# replace actual newlines with the literal \n sequence.
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_CONTENT\n-----END PRIVATE KEY-----\n"
+```
+
+Notes:
+- The code in `app/api/_utils/firebaseAdmin.ts` reads these variables and will throw an error if they are missing.
+- For many hosting providers you must escape newlines in `FIREBASE_PRIVATE_KEY` (replace real newlines with `\n`). Locally you can keep real newlines by wrapping the value in quotes.
+
 ### 7. Create Firestore Indexes (if needed)
 
 If you get index errors when running queries, Firebase will show a link in the console error to auto-create the index. Just click it!

--- a/README.md
+++ b/README.md
@@ -77,10 +77,31 @@ npm install
 
 ### 4️⃣ Configure Environment Variables
 
-Create a file named `.env.local` in your project root directory and paste your Firebase configuration 👇
+Copy the example env file and populate the values. The repo includes a committed ` .env.example` with the variables used by the project.
+
+PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Unix / macOS:
 
 ```bash
-# 🔓 Firebase Client Configuration (Visible to Browser)
+cp .env.example .env
+```
+
+Then open `.env` and fill in the values. Notes:
+- Client-side vars should be `NEXT_PUBLIC_*` (used by Next.js in `src/lib/firebase.ts`). Some files and comments reference `VITE_*`; if you use a Vite-based workflow, the example includes those variants as well.
+- Server-side (Admin) vars are required for Firebase Admin SDK and must never be exposed to the browser. These are:
+   - `FIREBASE_PROJECT_ID`
+   - `FIREBASE_CLIENT_EMAIL`
+   - `FIREBASE_PRIVATE_KEY` (must contain newlines; in many hosts you should replace real newlines with `\n`)
+
+Example values you should populate in `.env`:
+
+```env
+# Client (public) - set these for the browser
 NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
@@ -88,17 +109,19 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 
-# 🔐 Firebase Admin SDK (Server-side only – Keep this secret!)
+# Server (admin) - keep these secret
 FIREBASE_PROJECT_ID=your_project_id
 FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project.iam.gserviceaccount.com
 FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n"
 
-# 🤖 Optional: Gemini AI Integration
-GEMINI_API_KEY=your-gemini-api-key
-GEMINI_MODEL=gemini-2.0-flash-exp
+# Optional: Gemini AI (examples included)
+VITE_GEMINI_API_KEY=your_gemini_api_key
+VITE_GEMINI_MODEL=gemini-2.5-pro
+GEMINI_API_KEY=your_gemini_api_key
+GEMINI_MODEL=gemini-2.5-pro
 ```
 
-> ⚠️ **Important:** Do not share or commit your `.env.local` file. Add it to `.gitignore`.
+> ⚠️ **Important:** Do not share or commit your `.env` file. `.gitignore` already excludes `.env` and `.env.local`.
 
 ---
 


### PR DESCRIPTION
# Title: chore(docs): add .env.example and document env setup

## Summary

This PR adds an example environment file and documentation updates so contributors know which environment variables are required for local development and production deployments.

## Changes

- Add ` .env.example` listing client and server env var names and usage notes
- Update `README.md` with instructions to copy ` .env.example` and populate values
- Update `FIREBASE_SETUP.md` with service account instructions and server env vars
- Update `FEATURE_AI_ENRICHMENT.md` with Gemini key guidance

## Related issues

- Closes / relates to: #63

## Files changed (high-level)

- `/.env.example` (new)
- `/README.md` (edited)
- `/FIREBASE_SETUP.md` (edited)
- `/FEATURE_AI_ENRICHMENT.md` (edited)

## Checklist for reviewers

- [ ] Confirm ` .env.example` contains all env var names used by the codebase (client and server)
- [ ] Confirm `README.md` instructions are clear about `NEXT_PUBLIC_*` vs server-only vars
- [ ] Confirm `FIREBASE_SETUP.md` documents how to obtain service account JSON and how to set `FIREBASE_PRIVATE_KEY` (newline escaping)
- [ ] Confirm `FEATURE_AI_ENRICHMENT.md` explains Gemini key usage and server vs client recommendations
- [ ] Confirm `.gitignore` excludes `.env` and other secrets (already present)

## How to test locally

1. Checkout the branch: `git checkout docs/add-env-example`
2. Copy example env: `Copy-Item .env.example .env` (PowerShell) or `cp .env.example .env` (Unix)
3. Fill in placeholder values (use test Firebase project and test Gemini key if available)
4. Run dev server: `npm run dev`
5. Verify app loads and Firebase client initialization does not throw errors. For server-admin features, ensure `FIREBASE_PRIVATE_KEY` and other admin vars are set when exercising server endpoints.

## Notes for maintainers

- This PR intentionally keeps `.env.example` free of secrets. Contributors should populate local `.env` files and never commit them.
- If you prefer a different naming scheme (`NEXT_PUBLIC_*` vs `VITE_*`), we included both variants in ` .env.example` for clarity; consider consolidating in future cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup guides with clearer environment variable configuration instructions.
  * Added comprehensive Gemini API key integration documentation.
  * Expanded Firebase authentication setup guidance, including server-side credential configuration.
  * Provided platform-specific commands for environment setup on different operating systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->