### PR TITLE
Make Firebase client init build-safe

### DIFF
--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -12,7 +12,7 @@ import {
 } from 'firebase/auth';
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { authFetch, jsonAuthFetch } from '../lib/authFetch';
-import { auth } from '../lib/firebase';
+import { auth, isFirebaseClientConfigured } from '../lib/firebase';
 
 interface AuthContextType {
   user: FirebaseUser | null;
@@ -24,6 +24,7 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const firebaseConfigError = new Error('Firebase client configuration is missing.');
 
 const normalizeUsername = (value?: string | null) => {
   const fallback = `user_${Date.now().toString().slice(-6)}`;
@@ -41,6 +42,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!auth) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(auth, (u) => {
       setUser(u);
       setLoading(false);
@@ -51,6 +58,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signUp = async (email: string, password: string, username: string) => {
     try {
+      if (!auth || !isFirebaseClientConfigured) {
+        throw firebaseConfigError;
+      }
+
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
 
@@ -77,6 +88,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signIn = async (email: string, password: string) => {
     try {
+      if (!auth || !isFirebaseClientConfigured) {
+        throw firebaseConfigError;
+      }
+
       await signInWithEmailAndPassword(auth, email, password);
       return { error: null };
     } catch (error) {
@@ -86,6 +101,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signInWithGoogle = async () => {
     try {
+      if (!auth || !isFirebaseClientConfigured) {
+        throw firebaseConfigError;
+      }
+
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(auth, provider);
       const user = result.user;
@@ -138,6 +157,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const signOut = async () => {
+    if (!auth) return;
     await firebaseSignOut(auth);
   };
 

--- a/app/lib/firebase.ts
+++ b/app/lib/firebase.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { Auth, getAuth } from 'firebase/auth';
+import { Firestore, getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,7 +13,18 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase only if not already initialized
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+const hasFirebaseClientConfig = Boolean(
+  firebaseConfig.apiKey &&
+  firebaseConfig.authDomain &&
+  firebaseConfig.projectId &&
+  firebaseConfig.appId
+);
+
+// Avoid initializing Firebase during CI/prerender builds that do not have public Firebase env vars.
+const app = hasFirebaseClientConfig
+  ? (getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0])
+  : null;
+
+export const auth: Auth | null = app ? getAuth(app) : null;
+export const db: Firestore | null = app ? getFirestore(app) : null;
+export const isFirebaseClientConfigured = hasFirebaseClientConfig;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in, sign-up, and sign-out behavior when authentication services aren’t available.
  * Prevented login flows from continuing when required client-side configuration is missing, returning a clear error instead.
  * Avoided loading issues by cleanly handling cases where authentication is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->