### PR TITLE
Exclude dumpit-extension from root tsconfig and restrict auth sync

### DIFF
--- a/dumpit-extension/src/content/content-script.ts
+++ b/dumpit-extension/src/content/content-script.ts
@@ -15,8 +15,18 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 // Listen for custom event from DumpIt webpage
 document.addEventListener('DUMPIT_EXTENSION_AUTH', (e: any) => {
   const token = e.detail?.token;
-  if (token) {
-    chrome.storage.local.set({ token });
-    console.log('[DumpIt Extension] Successfully synchronized Auth token from website!');
-  }
+  if (!token) return;
+
+  const currentOrigin = window.location.origin;
+  
+  // Verify that the origin is either localhost:3000 or matches the configured API URL
+  chrome.storage.local.get('apiBaseUrl', (data) => {
+    const configuredOrigin = data.apiBaseUrl ? new URL(data.apiBaseUrl).origin : 'http://localhost:3000';
+    if (currentOrigin === 'http://localhost:3000' || currentOrigin === configuredOrigin) {
+      chrome.storage.local.set({ token });
+      console.log('[DumpIt Extension] Successfully synchronized Auth token from website!');
+    } else {
+      console.warn('[DumpIt Extension] Blocked auth sync from untrusted origin:', currentOrigin);
+    }
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,8 +44,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"
-, "dumpit-extension/popup.js"  ],
+  ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dumpit-extension"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token handling by only saving website-auth tokens when the page origin matches the configured API origin, helping prevent tokens from being stored on unexpected sites.
  * Added a safer default origin so local development continues to work as expected.
* **Chores**
  * Updated TypeScript file discovery to ignore an additional extension directory during compilation and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->