### PR TITLE
feat: resonate design language with Stackd - Space Grotesk + Inter + zinc palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,18 +5,30 @@
 @layer base {
   :root {
     color-scheme: light;
+    /* Font vars wired from next/font in layout.tsx */
+    --font-heading: var(--font-space-grotesk);
+    --font-body: var(--font-inter);
   }
 
   html {
     scroll-behavior: smooth;
+    /* Space Grotesk default via Tailwind fontFamily.sans */
   }
 
   body {
-    @apply bg-stone-50 text-slate-950 antialiased dark:bg-slate-950 dark:text-slate-50;
+    @apply bg-zinc-50 text-zinc-950 antialiased dark:bg-zinc-950 dark:text-zinc-50;
+    /* Inter for body text — readable long-form */
+    font-family: var(--font-inter, var(--font-space-grotesk), ui-sans-serif, system-ui, sans-serif);
+  }
+
+  /* Headings: Space Grotesk with tighter tracking */
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-space-grotesk, ui-sans-serif, system-ui, sans-serif);
+    @apply tracking-tight;
   }
 
   * {
-    @apply border-slate-200 dark:border-slate-800;
+    @apply border-zinc-200 dark:border-zinc-800;
   }
 
   /* ── View Transition: animated theme toggle ────────────────────────────── */
@@ -46,27 +58,30 @@
 
 @layer components {
   .app-surface {
-    @apply border border-slate-200/80 bg-white/90 shadow-sm shadow-slate-200/60 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 dark:shadow-black/20;
+    @apply border border-zinc-200/80 bg-white/90 shadow-sm shadow-zinc-200/60 backdrop-blur dark:border-zinc-800 dark:bg-zinc-900/80 dark:shadow-black/20;
   }
 
   .app-panel {
-    @apply rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900;
+    @apply rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900;
   }
 
   .app-muted-panel {
-    @apply rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900/60;
+    @apply rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/60;
   }
 
   .app-input {
-    @apply w-full rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-950 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-blue-500 dark:focus:ring-blue-950;
+    @apply w-full rounded-lg border border-zinc-200 bg-white px-3 py-2.5 text-sm text-zinc-950 outline-none transition focus:border-blue-400 focus:ring-4 focus:ring-blue-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-50 dark:focus:border-blue-500 dark:focus:ring-blue-950;
+    font-family: var(--font-inter, ui-sans-serif, system-ui, sans-serif);
   }
 
   .app-label {
-    @apply mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-200;
+    @apply mb-1.5 block text-sm font-medium text-zinc-700 dark:text-zinc-200;
   }
 
   .app-chip {
-    @apply inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300;
+    @apply inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-xs font-medium text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300;
+    font-family: var(--font-space-grotesk, ui-sans-serif, system-ui, sans-serif);
+    @apply tracking-wide;
   }
 
   .app-chip-ai {
@@ -83,6 +98,11 @@
 
   .app-focus {
     @apply focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-blue-100 dark:focus-visible:ring-blue-950;
+  }
+
+  /* Inter utility for body text sections */
+  .font-inter {
+    font-family: var(--font-inter, ui-sans-serif, system-ui, sans-serif);
   }
 }
 
@@ -139,20 +159,20 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
+  background: #d4d4d8;  /* zinc-300 */
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
+  background: #a1a1aa;  /* zinc-400 */
 }
 
 .dark ::-webkit-scrollbar-thumb {
-  background: #475569;
+  background: #3f3f46;  /* zinc-700 */
 }
 
 .dark ::-webkit-scrollbar-thumb:hover {
-  background: #64748b;
+  background: #52525b;  /* zinc-600 */
 }
 
 /* Gradient radial background */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,32 @@
 import type { Metadata } from 'next'
+import { Space_Grotesk, Inter } from 'next/font/google'
 import './globals.css'
 import { RootLayoutClient } from './RootLayoutClient'
 
+// Space Grotesk — geometric, modern, developer-centric (primary/heading font)
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-space-grotesk',
+  display: 'swap',
+})
+
+// Inter — highly legible UI sans-serif (secondary/body font)
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
 export const metadata: Metadata = {
-  title: 'Dumpit',
-  description: 'Dump your resources, find them later',
+  title: 'DumpIt — Your AI Second Brain',
+  description: 'Index everything you save — links, notes, PDFs — and ask questions across it all. Via web, browser extension, API, or Claude MCP.',
   icons: {
     icon: '/favicon.ico',
+  },
+  openGraph: {
+    title: 'DumpIt — Your AI Second Brain',
+    description: 'Stop losing what you learn. DumpIt indexes your saved content and lets you ask anything.',
+    type: 'website',
   },
 }
 
@@ -16,7 +36,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${spaceGrotesk.variable} ${inter.variable}`}>
       <body suppressHydrationWarning>
         <RootLayoutClient>
           {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,14 @@ export default {
   darkMode:'class',
   theme: {
     extend: {
+      fontFamily: {
+        // Space Grotesk — geometric, developer-centric headings
+        sans: ['var(--font-space-grotesk)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        // Inter — legible UI body text
+        inter: ['var(--font-inter)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        // Fallback mono
+        mono: ['ui-monospace', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+      },
       keyframes: {
         'fade-in': {
           '0%': { opacity: '0' },


### PR DESCRIPTION

Typography:
- Add Space Grotesk (headings, chips, primary font) via next/font/google
- Add Inter (body text, inputs) via next/font/google
- h1-h6 use Space Grotesk with tracking-tight (geometric, developer-centric)
- body text uses Inter (UI-legible, Stackd-style)
- Font vars: --font-space-grotesk / --font-inter as CSS custom properties

Color palette shift (slate -> zinc):
- bg-zinc-50 / dark:bg-zinc-950 root backgrounds (matches Stackd zinc-950 dark)
- border-zinc-200 / dark:border-zinc-800 (same border system as Stackd)
- All app-panel, app-surface, app-input, app-label, app-chip shifted to zinc neutrals
- Scrollbar chrome updated to zinc-300/zinc-700

Design tokens:
- --font-heading / --font-body CSS vars in :root
- .font-inter utility class for body-heavy sections
- app-chip uses tracking-wide + Space Grotesk for crisp labels

Preserves DumpIt product identity: blue CTA, emerald success, violet/amber accents unchanged